### PR TITLE
Create the log directory and fix logrotate path

### DIFF
--- a/roundcubemail.logrotate
+++ b/roundcubemail.logrotate
@@ -1,4 +1,4 @@
-/usr/share/roundcubemail/logs/*.log {
+/var/log/roundcubemail/*.log {
     missingok
     su root apache
     notifempty

--- a/roundcubemail.spec
+++ b/roundcubemail.spec
@@ -64,7 +64,7 @@ mkdir -p %{buildroot}/etc/%{name}
 mkdir -p %{buildroot}/usr/share/%{name}/temp
 
 # Logs
-mkdir -p %{buildroot}/usr/share/%{name}/logs
+mkdir -p %{buildroot}/var/log/%{name}
 
 install -d -m 755 %{buildroot}%{_datadir}/%{name}
 cp -r %{name}-%{rcm_version}/%{name}-%{rcm_version}/* %{buildroot}%{_datadir}/%{name}
@@ -93,7 +93,7 @@ cp -a twofactor_gauthenticator-master/* %{buildroot}/usr/share/%{name}/plugins/t
 %config(noreplace) %{_sysconfdir}/logrotate.d/roundcubemail
 %dir %attr(0750,apache,apache) %{_datadir}/%{name}/temp
 %dir %attr(0750,apache,apache) %{_datadir}/%{name}/enigma
-%dir %attr(0750,apache,apache) %{_datadir}/%{name}/logs
+%dir %attr(0750,apache,apache) /var/log/%{name}
 %dir %attr(0755,root,root) %{_datadir}/%{name}/plugins/twofactor_gauthenticator
 %dir %attr(0755,root,root) /etc/%{name}
 


### PR DESCRIPTION
If you install roundcubemail for the first time to 1.4 version the log directory is not created. The logrotate path needs to be adjusted accordingly

https://github.com/NethServer/dev/issues/6591