### PR TITLE
bump to 1.4.13 (security fix)

### DIFF
--- a/roundcubemail.spec
+++ b/roundcubemail.spec
@@ -1,4 +1,4 @@
-%define rcm_version 1.4.12
+%define rcm_version 1.4.13
 Name:           roundcubemail
 Version: 1.4.11.2
 Release: 1%{?dist}

--- a/roundcubemail.spec
+++ b/roundcubemail.spec
@@ -1,4 +1,4 @@
-%define rcm_version 1.4.11
+%define rcm_version 1.4.12
 Name:           roundcubemail
 Version: 1.4.11.2
 Release: 1%{?dist}


### PR DESCRIPTION
security fix from upstream 

https://github.com/roundcube/roundcubemail/releases/tag/1.4.13

https://github.com/NethServer/dev/issues/6618